### PR TITLE
defaults bugfix

### DIFF
--- a/LSL/OpenCollar - leashParticle.lsl
+++ b/LSL/OpenCollar - leashParticle.lsl
@@ -134,7 +134,6 @@ list g_lLeashPrims;
 //global integer used for loops
 integer g_iLoop;
 string g_sScript;
-string g_sDefaults;
 
 debug(string sText)
 {
@@ -538,7 +537,6 @@ default
     state_entry()
     {
         g_sScript = "leashParticle_";
-        g_sDefaults = "leashDefaults_";
         g_kWearer = llGetOwner();
         FindLinkedPrims();
         StopParticles(TRUE);
@@ -914,13 +912,8 @@ default
             {
                 // load current settings
                 sToken = llGetSubString(sToken, i + 1, -1);                
-                SaveSettings(sToken, sValue, FALSE);             
-            }
-            else if (llGetSubString(sToken, 0, i) == g_sDefaults)
-            {
-                // load default settings
-                sToken = llGetSubString(sToken, i + 1, -1);
-                SaveDefaultSettings(sToken,sValue);
+                SaveSettings(sToken, sValue, FALSE);
+                SaveDefaultSettings(sToken, sValue);
             }
             else if (sToken == "Global_CType") CTYPE = sValue;
             // in case wearer is currently leashed

--- a/SPARE_PARTS/OpenCollar - leashParticle.lsl
+++ b/SPARE_PARTS/OpenCollar - leashParticle.lsl
@@ -153,7 +153,6 @@ list g_lLeashPrims;
 //global integer used for loops
 integer g_iLoop;
 string g_sScript;
-string g_sDefaults;
 
 debug(string sText)
 {
@@ -580,7 +579,6 @@ default
     state_entry()
     {
         g_sScript = "leashParticle_";
-        g_sDefaults = "leashDefaults_";
         g_kWearer = llGetOwner();
         HUD_CHANNEL = (integer)("0x" + llGetSubString((string)g_kWearer, 2, 7)) + 1111;
         if (HUD_CHANNEL > 0) HUD_CHANNEL *= -1;
@@ -974,7 +972,7 @@ default
                 // load current settings
                 sToken = llGetSubString(sToken, i + 1, -1);                
                 SaveSettings(sToken, sValue, FALSE);
-                SaveDefaultSettings(sToken,sValue);
+                SaveDefaultSettings(sToken, sValue);
             }
             else if (sToken == "Global_CType") CTYPE = sValue;
             // in case wearer is currently leashed


### PR DESCRIPTION
"leashDefaults_" is not a valid ScriptName in the current settings
format (does not exist), so the script's default list is never filled,
causing revert to oc defaults on any default button usage (chain, etc),
regardless of settings in NC. Removed all reference to the variable, as
it is only used for that & repaired particle (current used) script to
properly establish it's defaults.
