### PR TITLE
self destructing bell

### DIFF
--- a/LSL/OpenCollar - bell.lsl
+++ b/LSL/OpenCollar - bell.lsl
@@ -278,6 +278,8 @@ BuildBellElementList()
     }
     else
     {
+        llMessageLinked(LINK_SET, MENUNAME_REMOVE, g_sParentMenu + "|" + g_sSubMenu, "");
+        llRemoveInventory(llGetScriptName());
         g_iBellAvailable=FALSE;
     }
 


### PR DESCRIPTION
if we don't have a bell element, the script cleans itself up; designs
that have a bell element that shouldn't be hidden will have to give it a
~nohide tag; in theory users wouldn't install bell if there is no such
element present, in practice users ask where the bell is after they
installed the script on their design that simply didn't feature the
element, this should clean up script load and confusion
