### PR TITLE
shorter dialog text and weblink

### DIFF
--- a/LSL/OpenCollarUpdater - Master.lsl
+++ b/LSL/OpenCollarUpdater - Master.lsl
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////////
 // ------------------------------------------------------------------------------ //
 //                           OpenCollarUpdater - Master                           //
-//                                 version 3.960                                  //
+//                                 version 3.961                                  //
 // ------------------------------------------------------------------------------ //
 // Licensed under the GPLv2 with additional requirements specific to Second Life® //
 // and other virtual metaverse environments.  ->  www.opencollar.at/license.html  //
@@ -185,14 +185,12 @@ BundleMenu(integer page) {
 }
 
 GiveMethodMenu() {
-    //string prompt = "\n\nChoose your install method:\n";
-    string prompt = "\n\nStandard: \"All you need for a fun BDSM experience on SL. The most popular features, full RLV support and a relay.\"\n";
-    prompt += "\nBasic: \"Just the basic modular collar framework and essential core features.\"\n";
-    prompt += "\nCustom: \"Add features for custom elements like label or bell. Un/install native texture support and select advanced features.\"\n";
-    //prompt += "\n[Developer]\n\"WARNING! This will install the full development workspace.\"\n";
-prompt += "\n\nThe currently selected method is ["+INSTALL_METHOD+"]\n";
+    string prompt = "\n\nStandard: \"The most popular features, RLV and Relay.\"\n";
+    prompt += "\nBasic: \"Just the modular core and essential basics.\"\n";
+    prompt += "\nCustom: \"Make your own selection of features here.\"\n\nwww.opencollar.at/updates\n";
+    prompt += "\n\nThe currently selected method is ["+INSTALL_METHOD+"]";
     list choices = ["Standard","Basic","Custom", "Developer"];
-    kDialogID = Dialog(llGetOwner(), prompt + "\n", choices, ["Help","START"],0);
+    kDialogID = Dialog(llGetOwner(), prompt, choices, ["Help","START"],0);
 }
 
 Debug(string str) {


### PR DESCRIPTION
weblink leads to essentially the same spot the Help button does but we
might want this for continuity throughout menus; shorter text should
encourage users who seek more documentation to follow up on a properly
formatted web page - the rest don't read it anyway, amirite?

(loosely related to #243)
