### PR TITLE
Added support for raw vector as Titler color

### DIFF
--- a/LSL/OpenCollar - titler.lsl
+++ b/LSL/OpenCollar - titler.lsl
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////////
 // ------------------------------------------------------------------------------ //
 //                              OpenCollar - titler                               //
-//                                 version 3.967                                  //
+//                                 version 3.968                                  //
 // ------------------------------------------------------------------------------ //
 // Licensed under the GPLv2 with additional requirements specific to Second Life® //
 // and other virtual metaverse environments.  ->  www.opencollar.at/license.html  //
@@ -12,7 +12,7 @@
 // ------------------------------------------------------------------------------ //
 ////////////////////////////////////////////////////////////////////////////////////
 
-// Nandana Singh, Satomi Ahn, Romka Swallowtail, littlemousy, Wendy Starfall
+// Miguael Liamano, Nandana Singh, Satomi Ahn, Romka Swallowtail, littlemousy, Wendy Starfall
 
 string g_sParentMenu = "Apps";
 string g_sFeatureName = "Titler";
@@ -126,6 +126,10 @@ integer UserCommand(integer iAuth, string sStr, key kAv){
             else ON_OFF = OFF ;
             g_kDialogID = Dialog(kAv, sPrompt, [SET,UP,DN,ON_OFF,"Color"], [UPMENU],0, iAuth);
         }
+    } else if (sCommand=="titlervector") {
+        string sVector= llDumpList2String(llDeleteSubList(lParams,0,0)," ");
+        g_vColor = (vector)sVector;
+        ShowHideText();
     } else if (sStr=="menu titlercolor" || sStr=="titlercolor") {
         list lColourNames;
         integer numColours=llGetListLength(g_lColours)/2;


### PR DESCRIPTION
This took me a while to figure out... At least it handles potential spaces in vectors fine and is about a quarter of the first attempt.
There is no menu feature, mainly because the color menu is full.

A little explanation.. Bear with me, I'm tired:

At first, I tried to add it as an optional sub-command to titlercolor, however it did create significant bugs and after several additional lines, was still unfixed. I went KISS (Keep It Simple, Stupid) and added a separate command that would handle it fine using 3 lines instead of 12 lines of buggy code.

Feel free to comment if improvement seems required.
