### PR TITLE
Update OpenCollar - leash.lsl

### DIFF
--- a/LSL/OpenCollar - leash.lsl
+++ b/LSL/OpenCollar - leash.lsl
@@ -786,7 +786,8 @@ default
                 g_vPos = vNewPos;
                 g_iTargetHandle = llTarget(g_vPos, (float)g_iLength);
             }
-            if (g_vPos != ZERO_VECTOR) llMoveToTarget(g_vPos,0.7);
+            integer iDist=llVecDist(g_vPos,llGetPos());// Distance between leasher and wearer
+            if (g_vPos != ZERO_VECTOR && iDist<1.2*g_iLength+10) llMoveToTarget(g_vPos,0.7);
             else llStopMoveToTarget();
         } else {
             DoUnleash();


### PR DESCRIPTION
this tries to fix part of the problems in #342 
the test line 789: iDist<1.2*g_iLength+10)
compares distance between wearer and leasher with a treshold distance that depends on the leash length.
So there are 3 zones
- under the leashlength : the leash is not taut and the wearer  is "free"
- over the leashlength : the leash is taut and the wearer  is pulled
- further (new) : the situation is abnormal and the leash is disabled until the leasher comes back close enough.
