### PR TITLE
bookmarks.lsl - catch owner hud force teleport commands

### DIFF
--- a/LSL/OpenCollar - bookmarks.lsl
+++ b/LSL/OpenCollar - bookmarks.lsl
@@ -203,7 +203,9 @@ You can enter:
                 }
             }
             if(found == 0) {
-                Notify(kID, "The bookmark '" + sCmd + "' has not been found in the " + CTYPE + " of " + llKey2Name(g_kWearer) + ".", FALSE);
+                //old hud command compatibility: 'o:176382.800000/261210.900000/3503.276000=force'
+                if (llSubStringIndex(sCmd,"o:") == 0) {}//llMessageLinked(LINK_SET, RLV_CMD, "tpt"+sCmd, kID); (enable this to support hud forcetp.  disabled now since rlvtp still does this
+                else Notify(kID, "The bookmark '" + sCmd + "' has not been found in the " + CTYPE + " of " + llKey2Name(g_kWearer) + ".", FALSE);
             } else if(found > 1) {
                 g_kMenuID = Dialog(kID, "More than one matching landmark was found in the " + CTYPE + " of " + llKey2Name(g_kWearer) + 
                     ".\nChoose a bookmark to teleport to.", matchedBookmarks, [UPMENU], 0, iNum);


### PR DESCRIPTION
Was sending an error to the hud wearer when using the latest hud release.

This trap catches the RLV command, and ignores it since rlvtp.lsl is dealing with that message right now

(tested on hud version 3.944)
