### PR TITLE
Removes string being sent as a key

### DIFF
--- a/LSL/OpenCollar - rlvex.lsl
+++ b/LSL/OpenCollar - rlvex.lsl
@@ -481,7 +481,7 @@ SetAllExs(string sVal)
                 }
                 string sStr = llDumpList2String(sCmd, ",");
                 //llOwnerSay("sending " + sStr);
-                llMessageLinked(LINK_SET, RLV_CMD, sStr, "rlvex");
+                llMessageLinked(LINK_SET, RLV_CMD, sStr, "");
                 //llOwnerSay("@" + sStr);
             }
         }
@@ -511,7 +511,7 @@ SetAllExs(string sVal)
                 }
                 string sStr = llDumpList2String(sCmd, ",");
                 //llOwnerSay("sending " + sStr);
-                llMessageLinked(LINK_SET, RLV_CMD, sStr, "rlvex");
+                llMessageLinked(LINK_SET, RLV_CMD, sStr, "");
                 //llOwnerSay("@" + sStr);
             }
         }
@@ -541,7 +541,7 @@ SetAllExs(string sVal)
             }
             string sStr = llDumpList2String(sCmd, ",");
             //llOwnerSay("sending " + sStr);
-            llMessageLinked(LINK_SET, RLV_CMD, sStr, "rlvex");
+            llMessageLinked(LINK_SET, RLV_CMD, sStr, "");
             //llOwnerSay("@" + sStr);
             @skip;
         }


### PR DESCRIPTION
never a good idea to send string "rlvex" in a Key field
