### PR TITLE
simplified the old attachment auth:

### DIFF
--- a/src/collar/oc_auth.lsl
+++ b/src/collar/oc_auth.lsl
@@ -114,10 +114,10 @@ integer FIND_AGENT = -9005;
 
 //added for attachment auth (garvin)
 integer ATTACHMENT_REQUEST = 600;
-integer ATTACHMENT_RESPONSE = 601;
+//integer ATTACHMENT_RESPONSE = 601;
 //new evolution style to handle attachment auth
-integer INTERFACE_REQUEST  = -9006;
-integer INTERFACE_RESPONSE = -9007;
+//integer INTERFACE_REQUEST  = -9006;
+//integer INTERFACE_RESPONSE = -9007;
 
 string UPMENU = "BACK";
 
@@ -647,7 +647,7 @@ default {
 
     link_message(integer iSender, integer iNum, string sStr, key kID) {
         if (iNum == CMD_ZERO) { //authenticate messages on CMD_ZERO
-            integer iAuth = Auth((string)kID, FALSE);
+            integer iAuth = Auth(kID, FALSE);
             if ( kID == g_kWearer && sStr == "runaway") {   // note that this will work *even* if the wearer is blacklisted or locked out
                 if (g_iRunawayDisable)
                     llMessageLinked(LINK_SET,NOTIFY,"0"+"Runaway is currently disabled.",g_kWearer);
@@ -693,14 +693,13 @@ default {
                 if (llGetListLength(g_lOwner)) SayOwners();
             }
         }
-    // JS: For backwards compatibility until all attachments/etc are rolled over to new interface
-        //added for attachment auth (Garvin)
-        else if (iNum == ATTACHMENT_REQUEST) {
-          integer iAuth = Auth((string)kID, TRUE);
-          llMessageLinked(LINK_SET, ATTACHMENT_RESPONSE, (string)iAuth+"|"+sStr, kID);
-        }
+// Redone simpler auth for attachments with direct reply to them from here without giving a reply first by LM to com - Otto (garvin.twine) aug 2015
+        else if (iNum == ATTACHMENT_REQUEST) //The reply is: "AuthReply|UUID|iAuth"
+            llRegionSayTo((key)llGetSubString(sStr,0,35),(integer)llGetSubString(sStr,36,-1),"AuthReply|"+(string)kID+"|"+(string)Auth(kID, TRUE));
+
+//remove the code below later to cleanup
     // JS: Remove ATTACHMENT_REQUEST & RESPONSE after all attachments have been updated properly
-        else if (iNum == INTERFACE_REQUEST) {
+      /*  else if (iNum == INTERFACE_REQUEST) {
             list lParams = llParseString2List(sStr, ["|"], []);
             string sTarget = llList2String(lParams, 0);
             string sCommand = llList2String(lParams, 1);
@@ -711,8 +710,8 @@ default {
                 }
                 else return; // do not send response if the message was erroneous
                 llMessageLinked(LINK_SET, INTERFACE_RESPONSE, llDumpList2String(lParams, "|"), kID);
-            }
-        } else if (iNum == DIALOG_RESPONSE) {
+            }*/
+        else if (iNum == DIALOG_RESPONSE) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
             if (~iMenuIndex) {
                 list lMenuParams = llParseString2List(sStr, ["|"], []);

--- a/src/collar/oc_com.lsl
+++ b/src/collar/oc_com.lsl
@@ -95,8 +95,8 @@ integer LM_SETTING_DELETE = 2003;
 //integer MENUNAME_REQUEST = 3000;
 //integer MENUNAME_RESPONSE = 3001;
 
-integer INTERFACE_REQUEST = -9006;
-integer INTERFACE_RESPONSE = -9007;
+//integer INTERFACE_REQUEST = -9006;
+//integer INTERFACE_RESPONSE = -9007;
 
 integer TOUCH_REQUEST = -9500;
 integer TOUCH_CANCEL = -9501;
@@ -360,7 +360,7 @@ default {
                 llMessageLinked(LINK_SET, CMD_SAFEWORD, "", "");
                 Notify(g_kWearer,"You used your safeword, your owners will be notified you did.",FALSE);
                 NotifyOwners("Your sub " + g_sWearerName + " has used the safeword. Please check on their well-being in case further care is required.","");
-                llMessageLinked(LINK_THIS, INTERFACE_RESPONSE, "safeword", "");
+               // llMessageLinked(LINK_THIS, INTERFACE_RESPONSE, "safeword", "");
                 return;
             }
         }
@@ -369,11 +369,14 @@ default {
             //Debug(sMsg);
             //do nothing if wearer isnt owner of the object
             if (llGetOwnerKey(kID) != g_kWearer) return;
+            //play ping pong with the Sub AO
             if (sMsg == "OpenCollar?") llRegionSayTo(g_kWearer, g_iInterfaceChannel, "OpenCollar=Yes");
-            //no idea who asks this and needs to know...
-           // else if (sMsg == "version") llMessageLinked(LINK_SET, CMD_WEARER, "attachmentversion", g_kWearer);  //main knows version number, main can respond to this request for us
-            else {
-                list lParams = llParseString2List(sMsg, ["|"], []);
+            else { // attachments can send auth request: llRegionSayTo(g_kWearer,g_InteraceChannel,"AuthRequest|UUID");
+                if (!llSubStringIndex(sMsg, "AuthRequest")) {
+                    llMessageLinked(LINK_SET,ATTACHMENT_REQUEST,(string)kID+(string)g_iInterfaceChannel,llGetSubString(sMsg,12,-1));
+                }
+            }
+               /* list lParams = llParseString2List(sMsg, ["|"], []);
                 integer iAuth = llList2Integer(lParams, 0);
                 if (iAuth == CMD_ZERO) { //auth request
                     string sCmd = llList2String(lParams, 1);
@@ -387,7 +390,7 @@ default {
                 else
                 // we received a unkown command, so we just forward it via LM into the cuffs
                     llMessageLinked(LINK_SET, ATTACHMENT_FORWARD, sMsg, kID);
-            }
+            }*/
         } else { //check for our prefix, or *
             if (!llSubStringIndex(sMsg, g_sPrefix)) sMsg = llGetSubString(sMsg, llStringLength(g_sPrefix), -1); //strip our prefix from command
             else if (!llSubStringIndex(sMsg, "/"+g_sPrefix)) sMsg = llGetSubString(sMsg, llStringLength(g_sPrefix)+1, -1); //strip our prefix plus a / from command
@@ -400,9 +403,10 @@ default {
     }
 
     link_message(integer iSender, integer iNum, string sStr, key kID) {
-        if (iNum==INTERFACE_RESPONSE) {
-            if (sStr == "safeword") llRegionSay(g_iHUDChan, "safeword");
-        } else if (iNum >= CMD_OWNER && iNum <= CMD_WEARER) {
+       // if (iNum==INTERFACE_RESPONSE) {
+       //     if (sStr == "safeword") llRegionSay(g_iHUDChan, "safeword");
+       // } else 
+        if (iNum >= CMD_OWNER && iNum <= CMD_WEARER) {
 
             list lParams = llParseString2List(sStr, [" "], []);
             string sCommand = llToLower(llList2String(lParams, 0));


### PR DESCRIPTION
attachments now can simply request an auth from a UUID with:
llRegionSayTo(g_kWearer, channel, "AuthRequest|UUID");
and get a reply like:
"AuthReply|UUID|iAuth"
