### PR TITLE
fixed false multi-page menus

### DIFF
--- a/src/collar/oc_dialog.lsl
+++ b/src/collar/oc_dialog.lsl
@@ -479,6 +479,7 @@ default {
                     if (llGetListLength(g_lSensorDetails) > 0)
                         dequeueSensor();
                     else g_bSensorLock=FALSE;
+                    g_iSelectAviMenu = FALSE;
                     return;
                 }
             }


### PR DESCRIPTION
after sensordialog calls with no dialog but just returning the first
search match, the flag for SelectAviMenu was not resetted and caused
next menu calls to be multi paged though they shouldnt be.
