### PR TITLE
for issue #663

### DIFF
--- a/src/collar/oc_com.lsl
+++ b/src/collar/oc_com.lsl
@@ -538,7 +538,7 @@ default {
             list lParams = llParseString2List(sStr, ["="], []);
             string sToken = llList2String(lParams, 0);
             string sValue = llList2String(lParams, 1);
-            if (sToken == "auth_owner" && llStringLength(sValue) > 0) g_lOwners = llParseString2List(sValue, [","], []);
+            if (sToken == "auth_owner") g_lOwners = llParseString2List(sValue, [","], []);
         } else if (iNum == LM_SETTING_RESPONSE) {
             list lParams = llParseString2List(sStr, ["="], []);
             string sToken = llList2String(lParams, 0);


### PR DESCRIPTION
the script did not clear the internal owner list when an empty list was
reported (what runaway does)
