### PR TITLE
limit SayOwners to one time per script reset(login) circle

### DIFF
--- a/src/collar/oc_auth.lsl
+++ b/src/collar/oc_auth.lsl
@@ -126,6 +126,7 @@ list g_lMenuIDs;
 integer g_iMenuStride = 3;
 
 key REQUEST_KEY;
+integer g_iFirstRun;
 
 string g_sSettingToken = "auth_";
 //string g_sGlobalToken = "global_";
@@ -603,6 +604,7 @@ default {
 
     state_entry() {
         if (llGetStartParameter()==825) llSetRemoteScriptAccessPin(0);
+        else g_iFirstRun = TRUE;
       /*  if (g_iProfiled){
             llScriptProfiler(1);
            // Debug("profiling restarted");
@@ -656,7 +658,10 @@ default {
                 else if (sToken == "trust") g_lTrust = llParseString2List(sValue, [","], [""]);
                 else if (sToken == "block") g_lBlock = llParseString2List(sValue, [","], [""]);
             } else if (llToLower(sStr) == "settings=sent") {
-                if (llGetListLength(g_lOwner) && !llGetStartParameter()) SayOwners();
+                if (llGetListLength(g_lOwner) && g_iFirstRun) {
+                    SayOwners();
+                    g_iFirstRun = FALSE;
+                }
             }
         } else if (iNum == AUTH_REQUEST) //The reply is: "AuthReply|UUID|iAuth" we rerute this to com to have the same prim ID 
             llMessageLinked(iSender,AUTH_REPLY, "AuthReply|"+(string)kID+"|"+(string)Auth(kID, TRUE), llGetSubString(sStr,0,35));

--- a/src/installer/oc_installer_sys.lsl
+++ b/src/installer/oc_installer_sys.lsl
@@ -97,6 +97,7 @@ integer BUNDLE_DONE = 98750;
 integer INSTALLION_DONE = 98751;
 
 integer g_iDone;
+integer g_iIsUpdate;
 
 string g_sVersion;
 // A wrapper around llSetScriptState to avoid the problem where it says it can't
@@ -163,6 +164,7 @@ default {
         llListen(g_initChannel, "", "", "");
         // set all scripts except self to not running
         // also build list of all bundles
+        list lBundleNumbers;
         integer i = llGetInventoryNumber(INVENTORY_ALL);
         do { i--;
             string sName = llGetInventoryName(INVENTORY_ALL, i);
@@ -176,9 +178,12 @@ default {
                 if (!llSubStringIndex(sName, "BUNDLE_")) {
                     list lParts = llParseString2List(sName, ["_"], []);
                     g_lBundles += [sName, llList2String(lParts, -1)];
+                    lBundleNumbers += llList2List(lParts,1,1);
                 }
             }
         } while (i);
+        if (~llListFindList(lBundleNumbers,["23"]) || ~llListFindList(lBundleNumbers,["42"])
+            || ~llListFindList(lBundleNumbers,["00"])) g_iIsUpdate = TRUE;
         g_lBundles = llListSort(g_lBundles,2,TRUE);
         SetFloatText();
         llParticleSystem([]);
@@ -219,6 +224,8 @@ default {
                 g_iPin = (integer)sParam;     
                 g_kCollarKey = kID;
                 g_iSecureChannel = (integer)llFrand(-2000000000 + 1);
+                if(g_iSecureChannel == 0) g_iSecureChannel = -1234567;
+                if (!g_iIsUpdate) g_iSecureChannel = -g_iSecureChannel;
                 llListen(g_iSecureChannel, "", g_kCollarKey, "");
                 llRemoteLoadScriptPin(g_kCollarKey, g_sShim, g_iPin, TRUE, g_iSecureChannel);  
             }                
@@ -252,8 +259,8 @@ default {
         }
     }
     timer() {
+        //if (llVecDist(llGetPos(),llList2Vector(llGetObjectDetails(llGetOwner(),[OBJECT_POS]),0)) > 30) llDie();
         if (g_iDone) llResetScript();
-        if (llVecDist(llGetPos(),llList2Vector(llGetObjectDetails(llGetOwner(),[OBJECT_POS]),0)) > 30) llDie();
     }
     
     on_rez(integer iStartParam) {

--- a/src/installer/oc_update_shim.lsl
+++ b/src/installer/oc_update_shim.lsl
@@ -71,6 +71,8 @@ list g_lCore5Scripts = ["oc_auth","oc_dialog","oc_rlvsys","oc_settings","oc_anim
 // they're stored as strings, in form "<cmd>|<data>", where cmd is either LM_SETTING_SAVE
 list g_lSettings;
 
+integer g_iIsUpdate;
+
 // list of deprecated tokens to remove from previous collar scripts
 list g_lDeprecatedSettingTokens = ["collarversion"];
 
@@ -104,6 +106,7 @@ Check4Core5Script() {
 default {
     state_entry() {
         g_iStartParam = llGetStartParameter();
+        if (g_iStartParam < 0 ) g_iIsUpdate = TRUE;
         // build script list
         integer i = llGetInventoryNumber(INVENTORY_SCRIPT);
         string sName;
@@ -184,7 +187,7 @@ default {
             //debug("responding: " + response);
             llRegionSayTo(kID, iChannel, sResponse);     
         } else if (sMsg == "Core5Done") Check4Core5Script();
-        else if (llSubStringIndex(sMsg, "DONE") == 0) {
+        else if (llSubStringIndex(sMsg, "DONE") == 0 && g_iIsUpdate) {
             //restore settings 
             integer n;
             integer iStop = llGetListLength(g_lSettings); 
@@ -208,8 +211,10 @@ default {
             llSetRemoteScriptAccessPin(0);
             // celebrate
             llOwnerSay("Update complete!");
-            //reboot scripts
-            llMessageLinked(5,CMD_OWNER,"reboot --f",llGetOwner());
+            if (g_iIsUpdate) {
+                //reboot scripts
+                llMessageLinked(5,CMD_OWNER,"reboot --f",llGetOwner());
+            }
             // delete shim script
             llRemoveInventory(llGetScriptName());
         }


### PR DESCRIPTION
only reboot scripts if bundles 00, 23 or 42 are installed, else dont
reboot as it is only a small app installation and no patch or update to
core scripts
