### PR TITLE
Added a command to test script integrity concerning the core5scripts in

### DIFF
--- a/src/collar/oc_anim.lsl
+++ b/src/collar/oc_anim.lsl
@@ -105,6 +105,7 @@ integer REBOOT = -1000;
 integer LINK_DIALOG = 3;
 integer LINK_RLV = 4;
 integer LINK_SAVE = 5;
+integer INTEGRITY = -1050;
 integer LM_SETTING_SAVE = 2000;
 integer LM_SETTING_RESPONSE = 2002;
 integer LM_SETTING_DELETE = 2003;
@@ -126,7 +127,6 @@ integer g_iAOChannel = -782690;
 string g_sSettingToken = "anim_";
 //string g_sGlobalToken = "global_";
 key g_kWearer;
-
 
 list g_lMenuIDs;  //three strided list of avkey, dialogid, and menuname
 integer g_iMenuStride = 3;
@@ -578,6 +578,7 @@ default {
             llSetRemoteScriptAccessPin(iPin);
             llMessageLinked(iLink, LOADPIN, (string)iPin+"@"+llGetScriptName(),llGetKey());
         } else if (iNum == REBOOT && sStr == "reboot") llResetScript();
+        else if (iNum == INTEGRITY) llMessageLinked(iLink,iNum,llGetScriptName(),"");
     }
 
     changed(integer iChange) {

--- a/src/collar/oc_auth.lsl
+++ b/src/collar/oc_auth.lsl
@@ -92,6 +92,7 @@ integer REBOOT              = -1000;
 integer LINK_DIALOG         = 3;
 integer LINK_RLV            = 4;
 integer LINK_SAVE           = 5;
+integer INTEGRITY = -1050;
 integer LM_SETTING_SAVE = 2000;
 //integer LM_SETTING_REQUEST = 2001;
 integer LM_SETTING_RESPONSE = 2002;
@@ -746,6 +747,7 @@ default {
             llSetRemoteScriptAccessPin(iPin);
             llMessageLinked(iSender, LOADPIN, (string)iPin+"@"+llGetScriptName(),llGetKey());
         } else if (iNum == REBOOT && sStr == "reboot") llResetScript();
+        else if (iNum == INTEGRITY) llMessageLinked(iSender,iNum,llGetScriptName(),"");
     }
 
     http_response(key kQueryId, integer iStatus, list lMeta, string sBody) { //response to a group name lookup

--- a/src/collar/oc_couples.lsl
+++ b/src/collar/oc_couples.lsl
@@ -120,6 +120,7 @@ integer REBOOT = -1000;
 integer LINK_DIALOG = 3;
 integer LINK_RLV  = 4;
 integer LINK_SAVE = 5;
+integer INTEGRITY = -1050;
 integer LM_SETTING_SAVE = 2000;
 //integer LM_SETTING_REQUEST = 2001;
 integer LM_SETTING_RESPONSE = 2002;
@@ -428,6 +429,7 @@ default {
             llSetRemoteScriptAccessPin(iPin);
             llMessageLinked(iLink, LOADPIN, (string)iPin+"@"+llGetScriptName(),llGetKey());
         } else if (iNum == REBOOT && sStr == "reboot") llResetScript();
+        else if (iNum == INTEGRITY) llMessageLinked(iLink,iNum,llGetScriptName(),"");
     }
     not_at_target() {
         llTargetRemove(g_iTargetID);

--- a/src/collar/oc_dialog.lsl
+++ b/src/collar/oc_dialog.lsl
@@ -70,6 +70,7 @@ integer NOTIFY = 1002;
 integer NOTIFY_OWNERS=1003;
 integer SAY = 1004;
 integer LINK_SAVE = 5;
+integer INTEGRITY = -1050;
 integer REBOOT = -1000;
 integer LOADPIN = -1904;
 integer LM_SETTING_SAVE = 2000;
@@ -740,6 +741,7 @@ default {
         else if (iNum == SAY)         Say(llGetSubString(sStr,1,-1),(integer)llGetSubString(sStr,0,0));
         else if (iNum==NOTIFY_OWNERS) NotifyOwners(sStr,(string)kID);
         else if (iNum == REBOOT && sStr == "reboot") llResetScript();
+        else if (iNum == INTEGRITY) llMessageLinked(iSender,iNum,llGetScriptName(),"");
     }
 
     listen(integer iChan, string sName, key kID, string sMessage) {

--- a/src/collar/oc_rlvsys.lsl
+++ b/src/collar/oc_rlvsys.lsl
@@ -88,6 +88,7 @@ integer CMD_RELAY_SAFEWORD = 511;
 //integer POPUP_HELP = 1001;
 integer NOTIFY = 1002;
 integer LINK_DIALOG = 3;
+integer INTEGRITY = -1050;
 integer REBOOT = -1000;
 integer LOADPIN = -1904;
 integer LINK_SAVE = 5;
@@ -519,6 +520,7 @@ default {
             llSetRemoteScriptAccessPin(iPin);
             llMessageLinked(iSender, LOADPIN, (string)iPin+"@"+llGetScriptName(),llGetKey());
         } else if (iNum == REBOOT && sStr == "reboot") llResetScript(); 
+        else if (iNum == INTEGRITY) llMessageLinked(iSender,iNum,llGetScriptName(),"");
         else if (g_iRlvActive) {
             llSetLinkPrimitiveParamsFast(g_iLEDLink,[PRIM_FULLBRIGHT,ALL_SIDES,TRUE,PRIM_BUMP_SHINY,ALL_SIDES,PRIM_SHINY_NONE,PRIM_BUMP_NONE,PRIM_GLOW,ALL_SIDES,0.4]);
             llSensorRepeat("N0thin9","abc",ACTIVE,0.1,0.1,0.22);

--- a/src/collar/oc_settings.lsl
+++ b/src/collar/oc_settings.lsl
@@ -89,6 +89,7 @@ integer LM_SETTING_EMPTY = 2004;
 integer DIALOG = -9000;
 integer DIALOG_RESPONSE = -9001;
 integer LINK_DIALOG = 3;
+integer INTEGRITY = -1050;
 integer REBOOT = -1000;
 integer LOADPIN = -1904;
 integer g_iRebootConfirmed;
@@ -401,7 +402,7 @@ default {
             integer iPin = (integer)llFrand(99999.0)+1;
             llSetRemoteScriptAccessPin(iPin);
             llMessageLinked(iLink, LOADPIN, (string)iPin+"@"+llGetScriptName(),llGetKey());
-        }
+        } else if (iNum == INTEGRITY) llMessageLinked(iLink,iNum,llGetScriptName(),"");
     }
 
     timer() {


### PR DESCRIPTION
non root prims.
prefix test integrity calls those scritps, collects replies and
interprets giving out a "test passed" or "test failed" with hints to the
failures
issue #750
