### PR TITLE
get rid of the 2 strided auth lists!

### DIFF
--- a/src/collar/oc_capture.lsl
+++ b/src/collar/oc_capture.lsl
@@ -19,7 +19,7 @@
 //                                          '  `+.;  ;  '      :            //
 //                                          :  '  |    ;       ;-.          //
 //                                          ; '   : :`-:     _.`* ;         //
-//           Capture - 160112.1           .*' /  .*' ; .*`- +'  `*'          //
+//           Capture - 160124.1           .*' /  .*' ; .*`- +'  `*'          //
 //                                       `*-*   `*-*  `*-*'                 //
 // ------------------------------------------------------------------------ //
 //  Copyright (c) 2014 - 2015 littlemousy, Sumi Perl, Wendy Starfall,       //
@@ -56,7 +56,7 @@
 
 key     g_kWearer;
 
-list    g_lMenuIDs;      //menu information, 5 strided list, userKey, menuKey, menuName, captorKey, captorName
+list    g_lMenuIDs;      //menu information, 4 strided list, userKey, menuKey, menuName, captorKey
 
 //MESSAGE MAP
 integer CMD_ZERO = 0;
@@ -116,13 +116,13 @@ string NameURI(key kID){
     return "secondlife:///app/agent/"+(string)kID+"/about";
 }
 
-Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPage, integer iAuth, string sName, key kCaptor, string sCaptor) {
+Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPage, integer iAuth, string sName, key kCaptor) {
     key kMenuID = llGenerateKey();
     llMessageLinked(LINK_DIALOG, DIALOG, (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
 
     integer iIndex = llListFindList(g_lMenuIDs, [kID]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName, kCaptor, sCaptor], iIndex, iIndex + 4);
-    else g_lMenuIDs += [kID, kMenuID, sName, kCaptor, sCaptor];
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName, kCaptor], iIndex, iIndex + 4);
+    else g_lMenuIDs += [kID, kMenuID, sName, kCaptor];
     //Debug("Menu:"+sName);
 }
 
@@ -139,7 +139,7 @@ CaptureMenu(key kId, integer iAuth) {
     }
     if (llGetListLength(g_lTempOwners) > 0)
         sPrompt += "\n\nCaptureped by: "+NameURI(llList2Key(g_lTempOwners,0));
-    Dialog(kId, sPrompt, lMyButtons, ["BACK"], 0, iAuth, "CaptureMenu", "", "");
+    Dialog(kId, sPrompt, lMyButtons, ["BACK"], 0, iAuth, "CaptureMenu", "");
 }
 
 saveTempOwners() {
@@ -152,24 +152,24 @@ saveTempOwners() {
     }
 }
 
-doCapture(key kCaptor, string sCaptor, integer iIsConfirmed) {
+doCapture(string sCaptorID, integer iIsConfirmed) {
     if (llGetListLength(g_lTempOwners)) {
-        llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"%WEARERNAME% is already captured, try another time.",kCaptor);
+        llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"%WEARERNAME% is already captured, try another time.",sCaptorID);
         return;
     }
-    if (llVecDist(llList2Vector(llGetObjectDetails( kCaptor,[OBJECT_POS] ),0),llGetPos()) > 10 ) { 
-        llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"You could capture %WEARERNAME% if you get a bit closer.",kCaptor);
+    if (llVecDist(llList2Vector(llGetObjectDetails(sCaptorID,[OBJECT_POS] ),0),llGetPos()) > 10 ) { 
+        llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"You could capture %WEARERNAME% if you get a bit closer.",sCaptorID);
         return;
     }
     if (!iIsConfirmed) {
-        Dialog(g_kWearer, "\nsecondlife:///app/agent/"+(string)kCaptor+"/about wants to capture you...", ["Allow","Reject"], ["BACK"], 0, CMD_WEARER, "AllowCaptureMenu", kCaptor, sCaptor);
+        Dialog(g_kWearer, "\nsecondlife:///app/agent/"+sCaptorID+"/about wants to capture you...", ["Allow","Reject"], ["BACK"], 0, CMD_WEARER, "AllowCaptureMenu", sCaptorID);
     }
     else {
-        llMessageLinked(LINK_SET, CMD_OWNER, "follow " + (string)kCaptor, kCaptor);
-        llMessageLinked(LINK_SET, CMD_OWNER, "yank", kCaptor);
-        llMessageLinked(LINK_DIALOG, NOTIFY, "0"+"You are at "+NameURI(kCaptor)+"'s whim.",g_kWearer);
-        llMessageLinked(LINK_DIALOG, NOTIFY, "0"+"%WEARERNAME% is at your mercy.\n\n/%CHANNEL%%PREFIX%menu\n/%CHANNEL%%PREFIX%pose\n/%CHANNEL%%PREFIX%restrictions\n/%CHANNEL%%PREFIX%sit\n/%CHANNEL%%PREFIX%help\n\nNOTE: During capture RP %WEARERNAME% cannot refuse your teleport offers and you will keep full control. To end the capture, please type: /%CHANNEL%%PREFIX%capture release\n\nHave fun!\n", kCaptor);
-        g_lTempOwners+=[kCaptor,sCaptor];
+        llMessageLinked(LINK_SET, CMD_OWNER, "follow " + sCaptorID, sCaptorID);
+        llMessageLinked(LINK_SET, CMD_OWNER, "yank", sCaptorID);
+        llMessageLinked(LINK_DIALOG, NOTIFY, "0"+"You are at "+NameURI(sCaptorID)+"'s whim.",g_kWearer);
+        llMessageLinked(LINK_DIALOG, NOTIFY, "0"+"%WEARERNAME% is at your mercy.\n\n/%CHANNEL%%PREFIX%menu\n/%CHANNEL%%PREFIX%pose\n/%CHANNEL%%PREFIX%restrictions\n/%CHANNEL%%PREFIX%sit\n/%CHANNEL%%PREFIX%help\n\nNOTE: During capture RP %WEARERNAME% cannot refuse your teleport offers and you will keep full control. To end the capture, please type: /%CHANNEL%%PREFIX%capture release\n\nHave fun!\n", sCaptorID);
+        g_lTempOwners=[sCaptorID];
         saveTempOwners();
         llSetTimerEvent(0.0);
     }
@@ -183,11 +183,11 @@ UserCommand(integer iNum, string sStr, key kID, integer remenu) {
         string sCaptor=llList2String(lSplit,1);
         if (iNum==CMD_OWNER || iNum==CMD_TRUSTED || iNum==CMD_GROUP) { //do nothing, owners get their own menu but cannot capture
         }
-        else Dialog(kID, "\nYou can try to capture %WEARERNAME%.\n\nReady for that?", ["Yes","No"], [], 0, iNum, "ConfirmCaptureMenu", kCaptor, sCaptor);
+        else Dialog(kID, "\nYou can try to capture %WEARERNAME%.\n\nReady for that?", ["Yes","No"], [], 0, iNum, "ConfirmCaptureMenu", kCaptor);
     }
     else if (sStrLower == "capture" || sStrLower == "menu capture") {
         if  (iNum!=CMD_OWNER && iNum != CMD_WEARER) {
-            if (g_iCaptureOn) Dialog(kID, "\nYou can try to capture %WEARERNAME%.\n\nReady for that?", ["Yes","No"], [], 0, iNum, "ConfirmCaptureMenu", kID, llKey2Name(kID));
+            if (g_iCaptureOn) Dialog(kID, "\nYou can try to capture %WEARERNAME%.\n\nReady for that?", ["Yes","No"], [], 0, iNum, "ConfirmCaptureMenu", kID);
             else llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"%NOACCESS%",kID);//Notify(kID,g_sAuthError, FALSE);
         } else CaptureMenu(kID, iNum); // an authorized user requested the plugin menu by typing the menus chat command
     }
@@ -315,7 +315,7 @@ default{
                     else UserCommand(iAuth,"capture "+sMessage,kAv,TRUE);
                 } else if (sMenu=="AllowCaptureMenu") {  //wearer must confirm when forced is off
                     if (sMessage == "BACK") UserCommand(iNum, "menu capture", kID, FALSE); //llMessageLinked(LINK_THIS, iAuth, "menu capture", kAv);
-                    else if (sMessage == "Allow") doCapture(kCaptor, sCaptor, TRUE);
+                    else if (sMessage == "Allow") doCapture(kCaptor, TRUE);
                     else if (sMessage == "Reject") {
                         llMessageLinked(LINK_DIALOG,NOTIFY,"0"+NameURI(kCaptor)+" didn't pass your face control. Sucks for them!",kAv);
                         llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"Looks like %WEARERNAME% didn't want to be captured after all. C'est la vie!",kCaptor);
@@ -323,7 +323,7 @@ default{
                 } else if (sMenu=="ConfirmCaptureMenu") {  //captor must confirm when forced is on
                     if (sMessage == "BACK") UserCommand(iNum, "menu capture", kID, FALSE); //llMessageLinked(LINK_SET, iAuth, "menu capture", kAv);
                     else if (g_iCaptureOn) {  //in case app was switched off in the mean time
-                        if (sMessage == "Yes") doCapture(kCaptor, sCaptor, g_iRiskyOn);
+                        if (sMessage == "Yes") doCapture(kCaptor, g_iRiskyOn);
                         else if (sMessage == "No") llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"You let %WEARERNAME% be.",kAv);
                     } else llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"%WEARERNAME% can no longer be captured",kAv);
                 }

--- a/src/collar/oc_dialog.lsl
+++ b/src/collar/oc_dialog.lsl
@@ -21,7 +21,7 @@
 //                    |     .'    ~~~~       \    / :                       //
 //                     \.. /               `. `--' .'                       //
 //                        |                  ~----~                         //
-//                           Dialog - 160124.2                              //
+//                           Dialog - 160124.3                              //
 // ------------------------------------------------------------------------ //
 //  Copyright (c) 2007 - 2015 Schmobag Hogfather, Nandana Singh,            //
 //  Cleo Collins, Satomi Ahn, Joy Stipe, Wendy Starfall, littlemousy,       //
@@ -155,7 +155,7 @@ list g_lColors = [
 ];
 
 
-integer g_iProfiled=1;
+/*integer g_iProfiled=1;
 Debug(string sStr) {
     //if you delete the first // from the preceeding and following  lines,
     //  profiling is off, debug is off, and the compiler will remind you to
@@ -165,7 +165,7 @@ Debug(string sStr) {
         llScriptProfiler(1);
     }
     llOwnerSay(llGetScriptName() + "(min free:"+(string)(llGetMemoryLimit()-llGetSPMaxMemory())+")["+(string)llGetFreeMemory()+"] :\n" + sStr);
-}
+}*/
 
 
 string NameURI(key kID){
@@ -203,7 +203,7 @@ Notify(key kID, string sMsg, integer iAlsoNotifyWearer) {
 NotifyOwners(string sMsg, string comments) {
     integer n;
     integer iStop = llGetListLength(g_lOwners);
-    for (n = 0; n < iStop; n += 2) {
+    for (; n < iStop; ++n) {
         key kAv = (key)llList2String(g_lOwners, n);
         if (comments=="ignoreNearby") {
             //we don't want to bother the owner if he/she is right there, so check distance
@@ -483,15 +483,15 @@ dequeueSensor() {
     list lParams = llParseStringKeepNulls(llList2String(g_lSensorDetails,2), ["|"], []);
     //sensor information is encoded in the first 5 fields of the lButtons list, ready to feed to the sensor command,
     list lSensorInfo = llParseStringKeepNulls(llList2String(lParams, 3), ["`"], []);
-/*    Debug("Running sensor with\n"+
+  /*  Debug("Running sensor with\n"+
         llList2String(lSensorInfo,0)+"\n"+
         llList2String(lSensorInfo,1)+"\n"+
         (string)llList2Integer(lSensorInfo,2)+"\n"+
         (string)llList2Float(lSensorInfo,3)+"\n"+
         (string)llList2Float(lSensorInfo,4)
-    );
-*/
-    if (llList2Integer(lSensorInfo,2) == AGENT) g_iSelectAviMenu = TRUE;
+    );*/
+
+    if (llList2Integer(lSensorInfo,2) == (integer)AGENT) g_iSelectAviMenu = TRUE;
     else g_iSelectAviMenu = FALSE;
     llSensor(llList2String(lSensorInfo,0),(key)llList2String(lSensorInfo,1),llList2Integer(lSensorInfo,2),llList2Float(lSensorInfo,3),llList2Float(lSensorInfo,4));
     g_iSensorTimeout=llGetUnixTime()+10;
@@ -585,7 +585,7 @@ default {
             //test for locked sensor subsystem
             //if subsys locked, do nothing
             //if subsys open, run sensor with first set of details in the list, and set timeout
-            //Debug(sStr);
+           // Debug(sStr);
             g_lSensorDetails+=[iSender, iNum, sStr, kID];
             if (! g_bSensorLock){
                 g_bSensorLock=TRUE;
@@ -595,7 +595,7 @@ default {
         //give a dialog with the options on the button labels
             //str will be pipe-delimited list with rcpt|prompt|page|backtick-delimited-list-buttons|backtick-delimited-utility-buttons|auth
             //Debug("DIALOG:"+sStr);
-            g_iSelectAviMenu = FALSE;
+            if (iSender != llGetLinkNumber()) g_iSelectAviMenu = FALSE;
             list lParams = llParseStringKeepNulls(sStr, ["|"], []);
             key kRCPT = llGetOwnerKey((key)llList2String(lParams, 0));
             integer iIndex = llListFindList(g_lRemoteMenus, [kRCPT]);

--- a/src/collar/oc_exceptions.lsl
+++ b/src/collar/oc_exceptions.lsl
@@ -21,7 +21,7 @@
 //                    |     .'    ~~~~       \    / :                       //
 //                     \.. /               `. `--' .'                       //
 //                        |                  ~----~                         //
-//                         Exceptions - 160112.1                            //
+//                         Exceptions - 160124.1                            //
 // ------------------------------------------------------------------------ //
 //  Copyright (c) 2008 - 2015 Satomi Ahn, Nandana Singh, Joy Stipe,         //
 //  Wendy Starfall, Medea Destiny, Garvin Twine, littlemousy,               //
@@ -280,7 +280,7 @@ SetAllExs() {
     integer i;
     string sRLVCmd = "@";
     integer iLength = llGetListLength(g_lSecOwners);
-    for (n = 0; n < iLength; n += 2) {
+    for (n = 0; n < iLength; ++n) {
         string sTmpOwner = llList2String(g_lSecOwners, n);
         if (llListFindList(g_lSettings, [sTmpOwner]) == -1 && sTmpOwner!=g_kWearer) {
             for (i = 0; i<iStop; i++) {
@@ -294,7 +294,7 @@ SetAllExs() {
         }
     }
     iLength = llGetListLength(g_lOwners+g_lTempOwners);
-    for (n = 0; n < iLength; n += 2) {
+    for (n = 0; n < iLength; ++n) {
         string sTmpOwner = llList2String(g_lOwners+g_lTempOwners, n);
         if (llListFindList(g_lSettings, [sTmpOwner]) == -1 && sTmpOwner!=g_kWearer) {
             for (i = 0; i<iStop; i++) {

--- a/src/collar/oc_settings.lsl
+++ b/src/collar/oc_settings.lsl
@@ -21,7 +21,7 @@
 //                    |     .'    ~~~~       \    / :                       //
 //                     \.. /               `. `--' .'                       //
 //                        |                  ~----~                         //
-//                          Settings - 160123.1                             //
+//                          Settings - 160124.1                             //
 // ------------------------------------------------------------------------ //
 //  Copyright (c) 2008 - 2015 Nandana Singh, Cleo Collins, Master Starship, //
 //  Satomi Ahn, Garvin Twine, Joy Stipe, Alex Carpenter, Xenhat Liamano,    //
@@ -296,10 +296,16 @@ LoadSetting(string sData, integer iLine) {
                         integer n;
                         do {//sanity check for valid entries
                             if (llList2Key(lTest,n)) //if this is not a valid key, it's useless
-                                lOut += llList2List(lTest,n,n+1);
-                            n = n+2;
-                        } while (n < llGetListLength(lTest));
+                                lOut += llList2String(lTest,n);
+                            integer iTest = llGetListLength(lOut);
+                            if (sToken == "owner" &&  iTest == 3)  jump next;
+                            else if (sToken == "trust" &&  iTest == 15)  jump next;
+                            else if (sToken == "block" &&  iTest == 9)  jump next;
+                        } while (++n < llGetListLength(lTest));
+                        @next;
                         sValue = llDumpList2String(lOut,",");
+                        lTest = [];
+                        lOut = [];
                     } 
                 }
                 if (sValue) g_lSettings = SetSetting(g_lSettings, sID + sToken, sValue);


### PR DESCRIPTION
finally we decided to remove the names from the auth lists as we use
anyway only IDs
from now on, no more strided auth lists for owner, trusted or block,
just UUIDs.
added a limiter to loadSettings so our limiits for the auth lists cannot
be cheated by websettings or .settings notecard
Also changed in oc_auth keys to strings as lsl treats them the same but we need them mostly as strings anyway
