### PR TITLE
stops the installer to play random sounds

### DIFF
--- a/src/installer/oc_installer_sys.lsl
+++ b/src/installer/oc_installer_sys.lsl
@@ -21,7 +21,7 @@
 //                    |     .'    ~~~~       \    / :                       //
 //                     \.. /               `. `--' .'                       //
 //                        |                  ~----~                         //
-//                       Installer System - 160120.1                        //
+//                       Installer System - 160129.1                        //
 // ------------------------------------------------------------------------ //
 //  Copyright (c) 2011 - 2016 Nandana Singh, Satomi Ahn, DrakeSystem,       //
 //  Wendy Starfall, littlemousy, Romka Swallowtail, Garvin Twine et al.     //
@@ -172,6 +172,7 @@ InitiateInstallation() {
     llPlaySound("6b4092ce-5e5a-ff2e-42e0-3d4c1a069b2f",1.0);
     //llPlaySound("3409e593-20ab-fd34-82b3-6ecfdefc0207",1.0); //ao
     //llPlaySound("95d3f6c5-6a27-da1c-d75c-a57cb29c883b",1.0); //remote hud
+    Debug("PLaying sound");
     llWhisper(iChan,(string)llGetOwner()+":.- ... -.-|"+g_sBuildVersion+"|"+(string)llGetKey());
     //llWhisper(iChan,"-.. --- / .- ---"); AO command
     //llWhisper(iChan,"-.. --- / .... ..- -.."); Remote HUD command
@@ -179,8 +180,8 @@ InitiateInstallation() {
 
 default {
     state_entry() {
-        llPreloadSound("6b4092ce-5e5a-ff2e-42e0-3d4c1a069b2f");
-        llPreloadSound("d023339f-9a9d-75cf-4232-93957c6f620c");
+       // llPreloadSound("6b4092ce-5e5a-ff2e-42e0-3d4c1a069b2f");
+       // llPreloadSound("d023339f-9a9d-75cf-4232-93957c6f620c");
         //llPreloadSound("3409e593-20ab-fd34-82b3-6ecfdefc0207"); // ao
        // llPreloadSound("95d3f6c5-6a27-da1c-d75c-a57cb29c883b"); //remote hud
         llSetTimerEvent(300.0);
@@ -240,7 +241,8 @@ default {
                 if (g_iDone) {
                     g_iDone = FALSE;
                     //llSetTimerEvent(30.0);
-                }  
+                }
+                Debug("sound");
                 llPlaySound("d023339f-9a9d-75cf-4232-93957c6f620c",1.0);
                 llWhisper(g_initChannel,"-.. ---|"+g_sBuildVersion); //tell collar we are here and to send the pin 
             } else if (sCmd == "ready") {


### PR DESCRIPTION
random repeats of the sounds where played without the script actually
triggered the sound by llPlaySound commands.
I removed the llPreloadSound on state entry and the issue was gone.
Seems to have been reported once logn time ago but doesnt seem to bother
many at all:
https://jira.secondlife.com/browse/VWR-23660
