### PR TITLE
dont check auth_public & auth_group for valid keys

### DIFF
--- a/src/installer/oc_update_shim.lsl
+++ b/src/installer/oc_update_shim.lsl
@@ -21,7 +21,7 @@
 //                    |     .'    ~~~~       \    / :                       //
 //                     \.. /               `. `--' .'                       //
 //                        |                  ~----~                         //
-//                         Update Shim - 160303.3                           //
+//                         Update Shim - 160319.1                           //
 // ------------------------------------------------------------------------ //
 //  Copyright (c) 2011 - 2016 Nandana Singh, Satomi Ahn, Wendy Starfall,    //
 //  littlemousy, Sumi Perl, Garvin Twine et al.                             //
@@ -201,7 +201,7 @@ default {
                     list lTest = llParseString2List(sSetting,["="],[]);
                     string sToken = llList2String(lTest,0);
                     if (llListFindList(g_lDeprecatedSettingTokens,[sToken]) == -1) { //If it doesn't exist in our list
-                        if (~llSubStringIndex(sToken,"auth")) { 
+                        if (~llListFindList(["auth_block","auth_trust","auth_owner"],[sToken])) {
                             lTest = llParseString2List(llGetSubString(sSetting,llSubStringIndex(sSetting,"=")+1,-1),[","],[]);
                             integer i;
                             for (;i<llGetListLength(lTest);++i) {


### PR DESCRIPTION
issue  #883 
When loading settings back into the settings script the values for auth_public and auth_group got lost in a validation check that shouldnt be done for them. Fixed here.
