### PR TITLE
add new value for distributor if an Original OpenCollar has been

### DIFF
--- a/src/collar/oc_com.lsl
+++ b/src/collar/oc_com.lsl
@@ -21,7 +21,7 @@
 //                    |     .'    ~~~~       \    / :                       //
 //                     \.. /               `. `--' .'                       //
 //                        |                  ~----~                         //
-//                         Communicator - 160320.1                          //
+//                         Communicator - 160321.1                          //
 // ------------------------------------------------------------------------ //
 //  Copyright (c) 2008 - 2016 Nandana Singh, Garvin Twine, Cleo Collins,    //
 //  Master Starship, Satomi Ahn, Joy Stipe, Wendy Starfall, littlemousy,    //
@@ -560,7 +560,7 @@ default {
         } while (i<10);
         i = llGetLinkNumber();
         if (i != 1) sMessage += "\noc_com\t(not in root prim!)";
-        string sSaveIntegrity = g_sGlobalToken+"integrity=";
+        string sSaveIntegrity = "intern_integrity=";
         if (llSubStringIndex(sMessage,"False") == -1 && llGetListLength(lTemp) == 1) {
             g_lFoundCore5Scripts = llListSort(g_lFoundCore5Scripts,2, TRUE);
             if (llListFindList(g_lFoundCore5Scripts,["LINK_ANIM",6,"LINK_AUTH",2,"LINK_DIALOG",3,"LINK_RLV",4,"LINK_SAVE",5])) {
@@ -578,7 +578,7 @@ default {
             if (llGetListLength(lTemp) ==1) lTemp = [];
             sMessage = "\n\nCore corruption detected:\n"+ llDumpList2String(lTemp,"\n")+sMessage;
             if (i == 1) sMessage += "\noc_com\t(root)";
-            llMessageLinked(LINK_SAVE,LM_SETTING_DELETE,g_sGlobalToken+"integrity","");
+            llMessageLinked(LINK_SAVE,LM_SETTING_DELETE,"intern_integrity","");
         }
         g_lFoundCore5Scripts = [];
         if (g_iVerify) {

--- a/src/collar/oc_sys.lsl
+++ b/src/collar/oc_sys.lsl
@@ -21,7 +21,7 @@
 //                    |     .'    ~~~~       \    / :                       //
 //                     \.. /               `. `--' .'                       //
 //                        |                  ~----~                         //
-//                           System - 160303.3                              //
+//                           System - 160321.1                              //
 // ------------------------------------------------------------------------ //
 //  Copyright (c) 2008 - 2016 Nandana Singh, Garvin Twine, Cleo Collins,    //
 //  Satomi Ahn, Joy Stipe, Wendy Starfall, littlemousy, Romka Swallowtail,  //
@@ -61,7 +61,7 @@ string g_sDevStage="";
 string g_sCollarVersion="6.1.3";
 string g_sFancyVersion="⁶⋅¹⋅³";
 integer g_iLatestVersion=TRUE;
-float g_fBuildVersion = 160320.1;
+float g_fBuildVersion = 160321.1;
 
 key g_kWearer;
 
@@ -146,6 +146,7 @@ integer g_iUpdateFromMenu;
 
 key github_version_request;
 string g_sDistributor;
+string g_sOtherDist;
 string g_sDistCard = ".distributor";
 string url_check = "https://raw.githubusercontent.com/VirtualDisgrace/Collar/live/web/~distributor";
 key g_kDistCheck;
@@ -252,8 +253,9 @@ UpdateConfirmMenu() {
 
 HelpMenu(key kID, integer iAuth) {
     string sPrompt="\nOpenCollar Version: "+g_sCollarVersion+g_sDevStage+"\nOrigin: ";
-    if (g_iOffDist) sPrompt += "["+NameGroupURI(g_sDistributor)+" Verified Distributor]";
-    else sPrompt += "Unverified";
+    if (g_iOffDist) sPrompt += "["+NameGroupURI(g_sDistributor)+" Official Distributor]";
+    else if (g_sOtherDist) sPrompt += NameGroupURI("agent/"+g_sOtherDist);
+    else sPrompt += "Unknown";
     sPrompt+="\n\nPrefix: %PREFIX%\nChannel: %CHANNEL%\nSafeword: "+g_sSafeWord;
     sPrompt += "\n\nThis %DEVICETYPE% has a "+g_sIntegrity+" core.";
     if(!g_iLatestVersion) sPrompt+="\n\n[http://www.opencollar.at/updates.html Update available!]";
@@ -300,8 +302,9 @@ UserCommand(integer iNum, string sStr, key kID, integer fromMenu) {
     } else if (sStr == "info") {
         string sMessage = "\n\nModel: "+llGetObjectName();
         sMessage += "\nOpenCollar Version: "+g_sCollarVersion+g_sDevStage+" ("+(string)g_fBuildVersion+")\nOrigin: ";
-        if (g_iOffDist) sMessage += "["+NameGroupURI(g_sDistributor)+" Verified Distributor]";
-        else sMessage += "Unverified";
+        if (g_iOffDist) sMessage += "["+NameGroupURI(g_sDistributor)+" Original Distributor]";
+        else if (g_sOtherDist) sMessage += NameGroupURI("agent/"+g_sOtherDist);
+        else sMessage += "Unknown";
         sMessage += "\nUser: "+llGetUsername(g_kWearer);
         sMessage += "\nPrefix: %PREFIX%\nChannel: %CHANNEL%\nSafeword: "+g_sSafeWord;
         sMessage += "\nThis %DEVICETYPE% has a "+g_sIntegrity+" core.\n";
@@ -405,8 +408,9 @@ UserCommand(integer iNum, string sStr, key kID, integer fromMenu) {
         }
     } else if (sCmd == "version") {
         string sVersion = "\n\nOpenCollar Version: "+g_sCollarVersion+g_sDevStage+" ("+(string)g_fBuildVersion+")\nOrigin: ";
-        if (g_iOffDist) sVersion += "["+NameGroupURI(g_sDistributor)+" Verified Distributor]\n";
-        else sVersion += "Unverified\n";
+        if (g_iOffDist) sVersion += "["+NameGroupURI(g_sDistributor)+" Original Distributor]\n";
+        else if (g_sOtherDist) sVersion += NameGroupURI("agent/"+g_sOtherDist);
+        else sVersion += "Unknown\n";
         if(!g_iLatestVersion) sVersion+="\nUPDATE AVAILABLE: A new patch has been released.\nPlease install at your earliest convenience. Thanks!\n\nwww.opencollar.at/updates\n";
         llMessageLinked(LINK_DIALOG,NOTIFY,"0"+sVersion,kID);
     }/* else if (sCmd == "objectversion") {
@@ -655,7 +659,7 @@ default
                 g_iLocked = (integer)sValue;
                 if (g_iLocked) llOwnerSay("@detach=n");
                 SetLockElementAlpha();
-            } else if (sToken == g_sGlobalToken+"integrity") 
+            } else if (sToken == "intern_integrity") 
                 g_sIntegrity = sValue;
             else if(sToken =="lock_locksound") {
                 if(sValue=="default") g_sLockSound=g_sDefaultLockSound;
@@ -665,6 +669,7 @@ default
                 else if ((key)sValue!=NULL_KEY || llGetInventoryType(sValue)==INVENTORY_SOUND) g_sUnlockSound=sValue;
             } else if (sToken == g_sGlobalToken+"safeword") g_sSafeWord = sValue;
             else if (sToken == g_sGlobalToken+"news") g_iNews = (integer)sValue;
+            else if (sToken == "intern_dist") g_sOtherDist = sValue;
             else if (sStr == "settings=sent") {
                 if (g_iNews) news_request = llHTTPRequest(news_url, [HTTP_METHOD, "GET", HTTP_VERBOSE_THROTTLE, FALSE], "");
             }

--- a/src/installer/oc_update_shim.lsl
+++ b/src/installer/oc_update_shim.lsl
@@ -21,7 +21,7 @@
 //                    |     .'    ~~~~       \    / :                       //
 //                     \.. /               `. `--' .'                       //
 //                        |                  ~----~                         //
-//                         Update Shim - 160319.1                           //
+//                         Update Shim - 160321.1                           //
 // ------------------------------------------------------------------------ //
 //  Copyright (c) 2011 - 2016 Nandana Singh, Satomi Ahn, Wendy Starfall,    //
 //  littlemousy, Sumi Perl, Garvin Twine et al.                             //
@@ -74,7 +74,7 @@ list g_lSettings;
 integer g_iIsUpdate;
 
 // list of deprecated tokens to remove from previous collar scripts
-list g_lDeprecatedSettingTokens = ["collarversion"];
+list g_lDeprecatedSettingTokens = ["collarversion","global_integrity"];
 
 integer CMD_OWNER = 500;
 


### PR DESCRIPTION
jailbroken, as Origin, the actual last object owner.
Create a new Setting token to save internal collar information, not
needed for any backups.
Filter those in "print settings" along with theme values.
Add a new command "debug settings" to show all saved settings.
Change global_integrity to intern_integrity
