### PR TITLE
Perform an additional operation on safewords to trim spaces

### DIFF
--- a/src/collar/oc_com.lsl
+++ b/src/collar/oc_com.lsl
@@ -416,6 +416,9 @@ default {
             if (llGetSubString(sw, 0, 3) == "/me ") sw = llGetSubString(sw, 4, -1);
             if (llGetSubString(sw, 0, 1) == "((" && llGetSubString(sw, -2, -1) == "))") sw = llGetSubString(sw, 2, -3);
             if (llSubStringIndex(sw, g_sPrefix)==0) sw = llGetSubString(sw, llStringLength(g_sPrefix), -1);
+            // Allow extra spaces, as in Firestorm's alt + enter "(( SAFEWORD ))", or a typo-ed "/me  SAFEWORD"
+            list lSw = llParseString2List(sw, [" "], []);
+            if(llGetListLength(lSw) == 1) sw = llList2String(lSw, 0);
             if (sw == g_sSafeWord) {
                 llMessageLinked(LINK_SET, CMD_SAFEWORD, "", "");
                 llRegionSayTo(g_kWearer,g_iInterfaceChannel,"%53%41%46%45%57%4F%52%44");

--- a/src/collar/oc_com.lsl
+++ b/src/collar/oc_com.lsl
@@ -414,11 +414,9 @@ default {
             // safeword can be the safeword or safeword said in OOC chat "((SAFEWORD))"
             // and may include prefix
             if (llGetSubString(sw, 0, 3) == "/me ") sw = llGetSubString(sw, 4, -1);
-            if (llGetSubString(sw, 0, 1) == "((" && llGetSubString(sw, -2, -1) == "))") sw = llGetSubString(sw, 2, -3);
+            // Allow for Firestorm style "(( SAFEWORD ))" by trimming.
+            if (llGetSubString(sw, 0, 1) == "((" && llGetSubString(sw, -2, -1) == "))") sw = llStringTrim(llGetSubString(sw, 2, -3), STRING_TRIM);
             if (llSubStringIndex(sw, g_sPrefix)==0) sw = llGetSubString(sw, llStringLength(g_sPrefix), -1);
-            // Allow extra spaces, as in Firestorm's alt + enter "(( SAFEWORD ))", or a typo-ed "/me  SAFEWORD"
-            list lSw = llParseString2List(sw, [" "], []);
-            if(llGetListLength(lSw) == 1) sw = llList2String(lSw, 0);
             if (sw == g_sSafeWord) {
                 llMessageLinked(LINK_SET, CMD_SAFEWORD, "", "");
                 llRegionSayTo(g_kWearer,g_iInterfaceChannel,"%53%41%46%45%57%4F%52%44");


### PR DESCRIPTION
Back when my safeword actually did something, I noticed that pressing alt+enter on Firestorm produced a message like `(( SAFEWORD ))` while OpenCollar expected a message like `((SAFEWORD))`. This seemed rather inconvenient in a situation that would merit needing to use a safeword.

My implementation converts the wearer's message into a list and and then pulls the first element from it only if the list is one element long. This works out because the safeword setting command does a similar thing where it pulls only one word from the message.

Now that I think about it, parsing every message someone sends sounds like a lot of overhead, so if you like this idea, I could look into adding an extra check if the first or last character of the string at that point is a space. If neither is a space, then this whole list thing is completely unnecessary. 😄 
