### PR TITLE
Fix typo preventing intern setting responses from being read

### DIFF
--- a/src/collar/oc_anim.lsl
+++ b/src/collar/oc_anim.lsl
@@ -570,7 +570,7 @@ default {
                      if (llGetAnimationOverride("Standing") != "")
                         g_iTweakPoseAO = (integer)sValue;
                 }
-            } else if (llGetSubString(sToken,0,i) == "intern") {
+            } else if (llGetSubString(sToken,0,i) == "intern_") {
                 sToken = llGetSubString(sToken,i+1,-1);
                 if (sToken == "AllowHover") {
                     g_iHoverOn = (integer)llGetSubString(sValue,0,0);


### PR DESCRIPTION
It turns out that while pose hover heights were being saved to the intern setting, they actually weren't being loaded properly because of a typo.
