### PR TITLE
Perform avatar check on leashto

### DIFF
--- a/src/collar/oc_leash.lsl
+++ b/src/collar/oc_leash.lsl
@@ -601,6 +601,8 @@ UserCommand(integer iAuth, string sMessage, key kMessageID, integer bFromMenu) {
                 if (llGetListLength(lParam) > 2) lPoints = llList2List(lParam, 2, -1);
                 //debug("leash target is key");//could be a post, or could be we specified an av key
                 //g_kLeashTargetDialogID = "";
+                if (llGetAgentSize((key)sVal)) g_iPassConfirmed = FALSE;
+                else g_iPassConfirmed = TRUE;
                 LeashTo((key)sVal, kMessageID, iAuth, lPoints, FALSE);
             } else 
                 SensorDialog(g_kCmdGiver, "\nWho shall we pass the leash?\n", sVal,iAuth,"LeashTarget", AGENT);


### PR DESCRIPTION
Here's a quick-and-dirty fix for #979, in case no one feels like making a cleaner, more comprehensive fix. For my fix, I just copied the "Is this an avatar?" check from `anchor` over to `leashto`.
