### PR TITLE
encode url for following sub

### DIFF
--- a/src/remote/oc_remote_bookmarks.lsl
+++ b/src/remote/oc_remote_bookmarks.lsl
@@ -415,7 +415,7 @@ default {
                         + "/"+(string)((integer)g_vLocalPos.y)
                         + "/"+(string)((integer)g_vLocalPos.z);
             llMessageLinked(LINK_THIS,CMD_REMOTE, "hudtpto:" + pos_str + "=force","");
-            llOwnerSay("Follow your Partner(s) right way by clicking here: secondlife:///app/teleport/"+llEscapeURL(g_sRegion+sPos));
+            llOwnerSay("Follow your Partner(s) right way by clicking here: secondlife:///app/teleport/"+llEscapeURL(g_sRegion)+sPos);
         }
         if(kID == g_kDataID) {
             list split;

--- a/src/remote/oc_remote_bookmarks.lsl
+++ b/src/remote/oc_remote_bookmarks.lsl
@@ -415,7 +415,7 @@ default {
                         + "/"+(string)((integer)g_vLocalPos.y)
                         + "/"+(string)((integer)g_vLocalPos.z);
             llMessageLinked(LINK_THIS,CMD_REMOTE, "hudtpto:" + pos_str + "=force","");
-            llOwnerSay("Follow your Partner(s) right way by clicking here: secondlife:///app/teleport/"+g_sRegion+sPos);
+            llOwnerSay("Follow your Partner(s) right way by clicking here: secondlife:///app/teleport/"+llEscapeURL(g_sRegion+sPos));
         }
         if(kID == g_kDataID) {
             list split;


### PR DESCRIPTION
Encodes the location section of the follow slurl to fix a problem with spaces in sim names.

relates to issue #1008