### PR TITLE
Display range limit status when listing access details

### DIFF
--- a/src/collar/oc_auth.lsl
+++ b/src/collar/oc_auth.lsl
@@ -458,11 +458,17 @@ UserCommand(integer iNum, string sStr, key kID, integer iRemenu) { // here iNum:
                 sOutput += "\n" + NameURI(llList2String(g_lBlock, --iLength));
             if (sOutput) llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"Blocked: "+sOutput,kID);
             //if (g_sGroupName) llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"Group: "+g_sGroupName,kID);
-            if (g_kGroup) llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"Group: secondlife:///app/group/"+(string)g_kGroup+"/about",kID);
+            if (g_kGroup) {
+                sOutput = "simwide";
+                if (g_iLimitRange) sOutput="chat range";
+                llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"secondlife:///app/group/"+(string)g_kGroup+"/about: "+sOutput,kID);
+            }
             sOutput="closed";
-            if (g_iOpenAccess) sOutput="open";
+            if (g_iOpenAccess) {
+                sOutput = "simwide";
+                if (g_iLimitRange) sOutput="chat range";
+            }
             llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"Public Access: "+ sOutput,kID);
-            if (!g_iLimitRange) if(g_iGroupEnabled || g_iOpenAccess) llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"Access range: simwide",kID);
         }
         else llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"%NOACCESS%",kID);
         if (iRemenu) AuthMenu(kID, iNum);

--- a/src/collar/oc_auth.lsl
+++ b/src/collar/oc_auth.lsl
@@ -462,6 +462,7 @@ UserCommand(integer iNum, string sStr, key kID, integer iRemenu) { // here iNum:
             sOutput="closed";
             if (g_iOpenAccess) sOutput="open";
             llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"Public Access: "+ sOutput,kID);
+            if (!g_iLimitRange) if(g_iGroupEnabled || g_iOpenAccess) llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"Access range: simwide",kID);
         }
         else llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"%NOACCESS%",kID);
         if (iRemenu) AuthMenu(kID, iNum);


### PR DESCRIPTION
There is a command to limit / unlimit the access range of collars for group and public users, but I couldn't find any location (other than a settings print) that would actually display the current state of this setting. I think this might put owners at risk of accidentally setting someone's collar to sim range and forgetting about it.

After trying a bunch of different things, I settled on on displaying this information as an extra row in the access list, only when it is applicable and set to simwide access:

* I decided on having it show up only when it is applicable because it's not really necessary to know that a collar has simwide access when the people who would need it can't access the collar in the first place.
* I decided on having nothing extra show at all when the collar is set to limited range access, because this is the default, and displaying this would likely cause confusion for inexperienced owners.