### PR TITLE
Drag landmark to OpenCollar remote to teleport partners there

### DIFF
--- a/src/remote/oc_remote_bookmarks.lsl
+++ b/src/remote/oc_remote_bookmarks.lsl
@@ -66,6 +66,8 @@ list   g_lDestinations_Slurls         = []; //Destination list direct from stati
 list   g_lVolatile_Destinations       = []; //These are in memory preferences that are not yet saved into the notecard
 list   g_lVolatile_Slurls             = []; //These are in memory preferences that are not yet saved into the notecard
 key    g_kRequestHandle               = NULL_KEY; //Sim Request Handle to convert global coordinates
+key    g_kLandmarkData                = NULL_KEY; //Landmark data request dataserver key
+string g_sLandmarkName                = ""; //Current landmark inventory item name
 vector g_vLocalPos                    = ZERO_VECTOR;
 string g_sRegion;
 
@@ -416,9 +418,21 @@ default {
                         + "/"+(string)((integer)g_vLocalPos.y)
                         + "/"+(string)((integer)g_vLocalPos.z);
             llMessageLinked(LINK_THIS,CMD_REMOTE, "hudtpto:" + pos_str + "=force","");
-            llOwnerSay("Follow your Partner(s) right way by clicking here: secondlife:///app/teleport/"+llEscapeURL(g_sRegion)+sPos);
-        }
-        if(kID == g_kDataID) {
+            // Teleporting with a global region offset (like from a landmark) results in an exposed secondlife: url, but it does seem to work corectly in Firestorm. Just hide it?
+            llOwnerSay("[secondlife:///app/teleport/"+llEscapeURL(g_sRegion)+sPos+" Click here to follow your partner(s)]");
+        } else if(kID == g_kLandmarkData) {
+            // Remove < and > from string
+            string sPosition = llGetSubString(sData, 1, -2);
+            // We are halfway there, so give another update on teleport status.
+            llOwnerSay("Teleporting your partner(s) to " + g_sLandmarkName);
+            // Delete all landmarks
+            while(g_sLandmarkName) {
+                llRemoveInventory(g_sLandmarkName);
+                g_sLandmarkName = llGetInventoryName(INVENTORY_LANDMARK, 0);
+            }
+            // sData is an offset from this region. This still works, even though it's a weird number.
+            TeleportTo(llGetRegionName() + "(" + sPosition + ")");
+        } else if(kID == g_kDataID) {
             list split;
             if(sData != EOF) {
                 if(llGetSubString(sData, 0, 2) != "") {
@@ -493,6 +507,14 @@ default {
         if(iChange & CHANGED_INVENTORY) {
             FailSafe();
             ReadDestinations();
+
+            // Check for landmarks in inventory, and begin a teleport to the first one.
+            if(llGetInventoryNumber(INVENTORY_LANDMARK)) {
+                g_sLandmarkName = llGetInventoryName(INVENTORY_LANDMARK, 0);
+                // This takes a few seconds, so give user a message.
+                llOwnerSay("Proccessing landmark. This may take a few moments.");
+                g_kLandmarkData = llRequestInventoryData(g_sLandmarkName);
+            }
         }
         if(iChange & CHANGED_OWNER)  llResetScript();
 /*

--- a/src/remote/oc_remote_bookmarks.lsl
+++ b/src/remote/oc_remote_bookmarks.lsl
@@ -512,7 +512,7 @@ default {
             if(llGetInventoryNumber(INVENTORY_LANDMARK)) {
                 g_sLandmarkName = llGetInventoryName(INVENTORY_LANDMARK, 0);
                 // This takes a few seconds, so give user a message.
-                llOwnerSay("Proccessing landmark. This may take a few moments.");
+                llOwnerSay("Processing landmark. This may take a few moments.");
                 g_kLandmarkData = llRequestInventoryData(g_sLandmarkName);
             }
         }


### PR DESCRIPTION
Since bookmarks aren't included in the collars anymore, it might be a good idea to make it even easier for people to teleport their partners around. The OpenCollar remote is conveniently located at a fixed location on your screen, so it makes a _really_ easy to use drag-and-drop target for inventory items.

This isn't an entirely new idea so I won't claim that I came up with it, but I wrote up a small feature that allows you to drag and drop a landmark onto your remote to teleport your partners to the location of your landmark.

![image](https://cloud.githubusercontent.com/assets/9897819/24696733/54594692-199f-11e7-98d1-b83f7ec827ed.png)

I was a little lazy and wanted to write as little code as possible (which conveniently results in a more consistent experience for users), but the downside of doing this is that processing a landmark and preparing for the teleport is slow. To "fix," this, I had the remote give two progress messages while this process is happening. They're spaced out just right to give a nice countdown feeling after you drop a landmark. 😊

![image](https://cloud.githubusercontent.com/assets/9897819/24696664/113dbdfc-199f-11e7-8823-435d00505052.png)

It's probably also important to mention that I changed the "follow your partners" message that you get. I noticed that my lazy landmark destination scripting resulted in teleport urls with out-of-sim offsets. These _do_ seem to work in Firestorm, but they just show up as secondlife: urls instead of the nicely presented location links that users are used to. I was worried that this might scare some people, so I wrapped the entire thing in a link and replaced it with a simple message about following your partners, with no indication of where the link takes you (you should know, after all).

![image](https://cloud.githubusercontent.com/assets/9897819/24696820/b00612cc-199f-11e7-85c4-992a102b328c.png)

Here's that ugly link you can send yourself in chat to see if it works (or displays nicely) for you:

```
secondlife:///app/teleport/Bondage/-49282/17534/1234
```

I just realized I misspelled processing.