### PR TITLE
Fix antislide run animation detection

### DIFF
--- a/src/collar/oc_anim.lsl
+++ b/src/collar/oc_anim.lsl
@@ -227,7 +227,7 @@ PoseMoveMenu(key kID, integer iPage, integer iAuth) {
     if (g_sPoseMoveWalk != "") {
        if (g_iTweakPoseAO) {
            sPrompt += "\n\nSelected Walk: "+g_sPoseMoveWalk;
-           if (llGetInventoryKey(g_sPoseMoveRun)) sPrompt += "\nSelected Run: "+g_sPoseMoveRun;
+           if (llGetInventoryType(g_sPoseMoveRun) == INVENTORY_ANIMATION) sPrompt += "\nSelected Run: "+g_sPoseMoveRun;
            else sPrompt += "\nSelected Run: ~run";
        }
        lButtons += ["☐ none"];
@@ -307,7 +307,7 @@ PlayAnim(string sAnim){  //plays anim and heightfix, depending on methods config
     if (g_iTweakPoseAO) {
         if (g_sPoseMoveWalk) llSetAnimationOverride( "Walking", g_sPoseMoveWalk);
         if (g_sPoseMoveRun) {
-            if (llGetInventoryKey(g_sPoseMoveRun)) llSetAnimationOverride( "Running", g_sPoseMoveRun);
+            if (llGetInventoryType(g_sPoseMoveRun) == INVENTORY_ANIMATION) llSetAnimationOverride( "Running", g_sPoseMoveRun);
             else if (llGetInventoryKey("~run")) llSetAnimationOverride( "Running", "~run");
         }
     }


### PR DESCRIPTION
The current method of detecting whether or not an antislide run animation exists actually determines whether or not a full permission run animation exists. I changed it to use `llGetInventoryType`, which works even for animations that are not full perm.

There is a similar check for the built-in `~run` animation that I didn't change, because there's no reason for `~run` not to be full perms.