### PR TITLE
Edit oc_relay's safeword condition so that it no longer checks if the linked message's key matches wearer's key

### DIFF
--- a/src/collar/oc_relay.lsl
+++ b/src/collar/oc_relay.lsl
@@ -453,7 +453,7 @@ default {
         } else if (iNum == RLV_REFRESH) {
             g_iRLV = TRUE;
             refreshRlvListener();
-        } else if (iNum == CMD_SAFEWORD && kID == g_kWearer) {
+        } else if (iNum == CMD_SAFEWORD) {
             g_iRecentSafeword = TRUE;
             refreshRlvListener();
             llSetTimerEvent(10.);


### PR DESCRIPTION
Hi! I wanted to start off by saying that I haven't *extensively* tested the bug I'm trying to fix, so it's possible that this isn't a bug at all. I'm sorry if that's the case!

---

I think this script's safeword processing is supposed to disable incoming relay commands for 10 seconds, just like what happens when you use the dedicated `relay safeword` command. This was not happening.

Safeword commands seem to be emitted from here:
https://github.com/VirtualDisgrace/opencollar/blob/26d0314832c4ba9f7231e726d02fa8c504b3aa89/src/collar/oc_com.lsl#L474

As you can see, this message has no key. Some searching suggests that no other script expects this message to contain a key, so I thought a good way to fix this issue would be to remove the requirement from this script.